### PR TITLE
Return list copies in ConfigManager and MessageLanguageManager

### DIFF
--- a/src/main/java/net/tiagofar78/prisonescape/managers/ConfigManager.java
+++ b/src/main/java/net/tiagofar78/prisonescape/managers/ConfigManager.java
@@ -260,7 +260,7 @@ public class ConfigManager {
     }
 
     public List<String> getAvailableLanguages() {
-        return _availableLanguages;
+        return new ArrayList<>(_availableLanguages);
     }
 
     public String getDefaultLanguage() {

--- a/src/main/java/net/tiagofar78/prisonescape/managers/MessageLanguageManager.java
+++ b/src/main/java/net/tiagofar78/prisonescape/managers/MessageLanguageManager.java
@@ -532,7 +532,7 @@ public class MessageLanguageManager {
 //	########################################
 
     public List<String> getUsage() {
-        return _usageMessage;
+        return new ArrayList<>(_usageMessage);
     }
 
     public String getStartCommandUsage() {


### PR DESCRIPTION
Closes #135 

Since `strings`, `doubles`, and `integers` are immutable, it was only necessary to return copies when private variables of the list type were being returned.