### PR TITLE
Fix part of ugly formatter settings

### DIFF
--- a/formatter-config.xml
+++ b/formatter-config.xml
@@ -328,7 +328,7 @@
 		<setting id="org.eclipse.jdt.core.formatter.wrap_before_conditional_operator" value="true"/>
 		<setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="16"/>
 		<setting id="org.eclipse.jdt.core.formatter.wrap_before_assignment_operator" value="false"/>
-		<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="0"/>
+		<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="56"/>
 		<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_for_loop_header" value="16"/>
 		<setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
 		<setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_loops" value="16"/>

--- a/src/main/java/net/tiagofar78/prisonescape/bukkit/BukkitMenu.java
+++ b/src/main/java/net/tiagofar78/prisonescape/bukkit/BukkitMenu.java
@@ -104,8 +104,12 @@ public class BukkitMenu {
 //  #                 Chest                 #
 //  #########################################
 
-    private static final int[] CHEST_CONTENT_INDEXES =
-            {SLOTS_PER_LINE * 1 + 2, SLOTS_PER_LINE * 1 + 3, SLOTS_PER_LINE * 1 + 4, SLOTS_PER_LINE * 1 + 5, SLOTS_PER_LINE * 1 + 6};
+    private static final int[] CHEST_CONTENT_INDEXES = {
+            SLOTS_PER_LINE * 1 + 2,
+            SLOTS_PER_LINE * 1 + 3,
+            SLOTS_PER_LINE * 1 + 4,
+            SLOTS_PER_LINE * 1 + 5,
+            SLOTS_PER_LINE * 1 + 6};
 
     public static void openChest(String playerName, List<Item> contents) {
         Player bukkitPlayer = Bukkit.getPlayer(playerName);

--- a/src/main/java/net/tiagofar78/prisonescape/items/ItemFactory.java
+++ b/src/main/java/net/tiagofar78/prisonescape/items/ItemFactory.java
@@ -4,8 +4,44 @@ import org.bukkit.inventory.ItemStack;
 
 public class ItemFactory {
 
-    private static Item[] items =
-            {new AntenaItem(), new BatteryItem(), new BoltsItem(), new BombItem(), new CellPhoneItem(), new CircuitBoardItem(), new CopperItem(), new DoorCodeItem(), new DuctTapeItem(), new EnergyDrinkItem(), new GoldBarItem(), new GoldenKeyItem(), new GrayKeyItem(), new HandcuffsItem(), new MatchesItem(), new MetalPlateItem(), new MetalShovelItem(), new MetalSpoonItem(), new NotePartItem(), new OilItem(), new PlasticPlateItem(), new PlasticShovelItem(), new PlasticSpoonItem(), new SearchItem(), new SelectNoneTeamItem(), new SelectPoliceTeamItem(), new SelectPrisionerTeamItem(), new StickItem(), new WireCutterItem(), new WrenchItem(), new ShopItem(), new TrapItem(), new CameraItem(), new SensorItem(), new RadarItem(), new OpenCamerasItem(), new MissionsItem()};
+    private static Item[] items = {
+            new AntenaItem(),
+            new BatteryItem(),
+            new BoltsItem(),
+            new BombItem(),
+            new CellPhoneItem(),
+            new CircuitBoardItem(),
+            new CopperItem(),
+            new DoorCodeItem(),
+            new DuctTapeItem(),
+            new EnergyDrinkItem(),
+            new GoldBarItem(),
+            new GoldenKeyItem(),
+            new GrayKeyItem(),
+            new HandcuffsItem(),
+            new MatchesItem(),
+            new MetalPlateItem(),
+            new MetalShovelItem(),
+            new MetalSpoonItem(),
+            new NotePartItem(),
+            new OilItem(),
+            new PlasticPlateItem(),
+            new PlasticShovelItem(),
+            new PlasticSpoonItem(),
+            new SearchItem(),
+            new SelectNoneTeamItem(),
+            new SelectPoliceTeamItem(),
+            new SelectPrisionerTeamItem(),
+            new StickItem(),
+            new WireCutterItem(),
+            new WrenchItem(),
+            new ShopItem(),
+            new TrapItem(),
+            new CameraItem(),
+            new SensorItem(),
+            new RadarItem(),
+            new OpenCamerasItem(),
+            new MissionsItem()};
 
     public static Item createItem(ItemStack bukkitItem) {
         for (Item item : items) {


### PR DESCRIPTION
This PR fixes part of #99 (closes #197)

 **Current behavior** 
![321696061-42097036-c833-4d1b-804c-d31e9937b7d6](https://github.com/TiagoFar78/PrisonEscape/assets/52565678/81cb3da6-7ed0-49ac-800a-83b8ee336ffd)

**Expected behavior** 
![321695754-8bff2863-9dc7-4b4b-a69b-daa5e97f0416](https://github.com/TiagoFar78/PrisonEscape/assets/52565678/e7baffd7-7a8a-4b21-9257-820ebbd2c610)

**New behavior**
![Screenshot_20240506_235941](https://github.com/TiagoFar78/PrisonEscape/assets/52565678/fee032ab-9c91-4ddd-b3a8-4f5945d898fc)

### Note:
I only committed the formatter changes, but not the formatted code.
